### PR TITLE
Add interpreter include support

### DIFF
--- a/src/ast.d
+++ b/src/ast.d
@@ -6,7 +6,7 @@ import std.typecons;
 import std.stdio;
 
 static const long WORD_SIZE = 64;
-static const int HEADER_TAG_WIDTH = WORD_SIZE / 8;
+static const int HEADER_TAG_WIDTH = 8;
 
 enum ASTTag {
   Nil,
@@ -108,10 +108,10 @@ BigInt astToBigInteger(ref AST v) {
   return *cast(BigInt*)v.data;
 }
 
-static const long MAX_AST_LENGTH = (long.sizeof * 8) - 1;
+static const ulong MAX_VALUE_LENGTH = pow(2, WORD_SIZE) - 1;
 
 Tuple!(void*, ulong) copyString(string s) {
-  ulong size = s.length + 1 > MAX_AST_LENGTH ? MAX_AST_LENGTH : s.length + 1;
+  ulong size = s.length + 1 > MAX_VALUE_LENGTH ? MAX_VALUE_LENGTH : s.length + 1;
 
   auto heapString = new char[size];
   foreach (i, c; s[0 .. size - 1]) {
@@ -168,7 +168,7 @@ Tuple!(AST, AST) astToList(AST v) {
 }
 
 AST makeVectorAst(AST[] v) {
-  ulong size = v.length > MAX_AST_LENGTH ? MAX_AST_LENGTH : v.length;
+  ulong size = v.length > MAX_VALUE_LENGTH ? MAX_VALUE_LENGTH : v.length;
   AST ve = { data: cast(long)v.ptr, header: size << HEADER_TAG_WIDTH | ASTTag.Vector };
   return ve;
 }

--- a/src/backends/interpreter/bsdi.d
+++ b/src/backends/interpreter/bsdi.d
@@ -1,7 +1,3 @@
-import std.functional;
-import std.file;
-import std.stdio;
-
 import parse;
 import ast;
 
@@ -9,11 +5,11 @@ import runtime;
 import value;
 
 int main(string[] args) {
-  char[] source = cast(char[])read(args[1]);
-  auto parsed = parse.read(source);
-  Value begin = makeSymbolAst("begin");
-  Value topLevelItem = makeListAst(begin, parsed);
   auto ctx = new Context;
+  auto include = makeSymbolAst("include");
+  auto source = makeStringAst(args[1]);
+  auto includeArgs = makeListAst(source, nilValue);
+  auto topLevelItem = makeListAst(include, includeArgs);
   eval(topLevelItem, ctx);
   return 0;
 }

--- a/test/include.yaml
+++ b/test/include.yaml
@@ -1,0 +1,16 @@
+cases:
+  - name: displays a string defined by in an included file
+    status: 0
+    stdout: This is my included string
+
+templates:
+- helper.scm: |
+
+    (define str "This is my included string")
+    
+- test.scm: |
+
+    (include "helper.scm")
+
+    (display str)
+


### PR DESCRIPTION
Add support for the `include` form in the interpreter backend that opens a file, `read`s the contents, and `eval`s the result. The `bsdi` entrypoint has been modified to directly use `include` on the supplied command-line argument.

This also fixes a bug in calculating the max available size -- it in fact has no correlation with the HEADER_TAG_WIDTH.