### PR TITLE
Add string methods and character literal support

### DIFF
--- a/examples/string.scm
+++ b/examples/string.scm
@@ -29,4 +29,22 @@
 (define l '(#\a #\b #\c))
 (show (list->string l))
 
-(newline)
+(show (string-upcase s))
+
+(show (string-downcase s))
+
+(show (substring s 0 5))
+
+(show '(1 2 3))
+
+(show (string->list s))
+
+(string-fill! s #\T)
+
+(show s)
+
+(show (string-length s))
+
+(define s "Hello")
+
+(string-fill! s \#T 2 4)

--- a/examples/string.scm
+++ b/examples/string.scm
@@ -1,3 +1,32 @@
-(display "Hello world!")
+(define (show it)
+  (display it)
+  (newline)
+  (newline))
+
+
+(define s "Hello world!")
+
+(show s)
+
+(show (string-length s))
+
+(show (string-ref s 1))
+
+(show (string=? s "Hello world!" s))
+
+(show (string=? s "Hello world?"))
+
+(show (string? 1))
+
+(show (string? "foo"))
+
+(string-set! s 0 #\C)
+
+(show s)
+
+(show (string-append s " This is BSDScheme!" " What are you?"))
+
+(define l '(#\a #\b #\c))
+(show (list->string l))
 
 (newline)

--- a/src/ast.d
+++ b/src/ast.d
@@ -11,6 +11,7 @@ static const int HEADER_TAG_WIDTH = 8;
 enum ASTTag {
   Nil,
   Integer,
+  Char,
   Bool,
   BigInteger,
   String,
@@ -33,6 +34,8 @@ string formatAst(AST v) {
     return astToBool(v) ? "#t" : "#f";
   case ASTTag.Symbol:
     return astToSymbol(v);
+  case ASTTag.Char:
+    return format("#\\%c", astToChar(v));
   case ASTTag.String:
     return astToString(v);
   case ASTTag.Nil:
@@ -84,6 +87,17 @@ bool astIsInteger(ref AST v) { return isAst(v, ASTTag.Integer); }
 
 long astToInteger(ref AST v) {
   return cast(long)v.data;
+}
+
+AST makeCharAst(char c) {
+  AST v = { data: c, header: ASTTag.Char };
+  return v;
+}
+
+bool astIsChar(ref AST v) { return isAst(v, ASTTag.Char); }
+
+char astToChar(ref AST v) {
+  return cast(char)v.data;
 }
 
 AST makeBoolAst(bool b) {

--- a/src/backends/interpreter/runtime.d
+++ b/src/backends/interpreter/runtime.d
@@ -189,12 +189,7 @@ Value namedLambda(Value arguments, Context ctx, string name) {
     auto valueTmp = astToList(parameters);
     while (true) {
       auto key = astToSymbol(keyTmp[0]);
-
       auto value = valueTmp[0];
-      // This special case is weird. Not sure if it is correct.
-      if (!astIsList(valueTmp[0])) {
-        value = eval(valueTmp[0], ctx);
-      }
 
       newCtx.set(key, value);
 

--- a/src/lex.d
+++ b/src/lex.d
@@ -11,6 +11,7 @@ enum TokenType {
 
 enum SchemeType {
   String,
+  Char,
   Symbol,
   Integer,
   Bool,
@@ -121,6 +122,23 @@ Token* lexBool(StringBuffer input) {
   return null;
 }
 
+Token* lexChar(StringBuffer input) {
+  if (input.current() == '#') {
+    input.next();
+
+    if (input.current() == '\\') {
+      input.next();
+
+      char[1] s = [input.current()];
+      return new Token(0, 0, "", s.dup, TokenType.Atom, SchemeType.Char);
+    }
+
+    input.previous();
+  }
+
+  return null;
+}
+
 Token* lexSymbol(StringBuffer input) {
   string symbol = "";
 
@@ -219,6 +237,10 @@ TokenBuffer lex(StringBuffer input) {
 
     if (token is null) {
       token = lexSymbol(input);
+    }
+
+    if (token is null) {
+      token = lexChar(input);
     }
 
     if (token is null) {

--- a/src/parse.d
+++ b/src/parse.d
@@ -54,6 +54,9 @@ Tuple!(Token*[], AST) parse(Token*[] tokens) {
       case SchemeType.String:
         atom = makeStringAst(token.value);
         break;
+      case SchemeType.Char:
+        atom = makeCharAst(token.value[0]);
+        break;
       default:
         atom = makeSymbolAst(token.value);
         break;

--- a/test/define-begin.yaml
+++ b/test/define-begin.yaml
@@ -1,0 +1,14 @@
+cases:
+  - name: define has implicit begin
+    status: 0
+    stdout: "Hey!\n\n"
+
+templates:
+- test.scm: |
+
+    (define (show it)
+      (display it)
+      (newline)
+      (newline))
+
+    (show "Hey!")

--- a/test/define-begin.yaml
+++ b/test/define-begin.yaml
@@ -1,15 +1,13 @@
 cases:
   - name: define has implicit begin
     status: 0
-    stdout: "Hey!\n\n"
+    stdout: "Hey!Hey!"
 
 templates:
 - test.scm: |
 
     (define (show it)
-      (begin
-        (display it)
-        (newline)
-        (newline)))
+      (display it)
+      (display it))
 
     (show "Hey!")

--- a/test/define-begin.yaml
+++ b/test/define-begin.yaml
@@ -7,8 +7,9 @@ templates:
 - test.scm: |
 
     (define (show it)
-      (display it)
-      (newline)
-      (newline))
+      (begin
+        (display it)
+        (newline)
+        (newline)))
 
     (show "Hey!")

--- a/test/lambda-list-arg.yaml
+++ b/test/lambda-list-arg.yaml
@@ -1,0 +1,8 @@
+cases:
+  - name: pass list to lambda
+    status: 0
+    stdout: "(1 2 3)"
+
+templates:
+  - test.scm: |
+     (display ((lambda (a) a)) '(1 2 3'))

--- a/test/lambda-list-arg.yaml
+++ b/test/lambda-list-arg.yaml
@@ -5,4 +5,4 @@ cases:
 
 templates:
   - test.scm: |
-     (display ((lambda (a) a)) '(1 2 3'))
+     (display ((lambda (a) a) '(1 2 3')))

--- a/test/lambda-list-arg.yaml
+++ b/test/lambda-list-arg.yaml
@@ -5,4 +5,4 @@ cases:
 
 templates:
   - test.scm: |
-     (display ((lambda (a) a) '(1 2 3')))
+     (display ((lambda (a) a) '(1 2 3)))

--- a/test/list-to-string.scm
+++ b/test/list-to-string.scm
@@ -1,0 +1,9 @@
+cases:
+  - name: basic
+    status: 0
+    stdout: abc
+
+templates:
+- test.scm: |
+
+    (display (list->string '(#\a #\b #\c)))

--- a/test/string-append.yaml
+++ b/test/string-append.yaml
@@ -1,0 +1,17 @@
+cases:
+  - name: basic
+    status: 0
+    stdout: "Hey! There!"
+
+    v: "\"Hey!\" \" There!\""
+
+  - name: multiple
+    status: 0
+    stdout: "Hey! There! Fellow!"
+
+    v: "\"Hey!\" \" There!\" \" Fellow!\""
+
+templates:
+- test.scm: |
+
+    (display (string-append {{ v }})

--- a/test/string-case.yaml
+++ b/test/string-case.yaml
@@ -1,0 +1,17 @@
+cases:
+  - name: upcase
+    status: 0
+    stdout: "HELLO!"
+
+    fun: string-upcase
+
+  - name: multiple
+    status: 0
+    stdout: "hello!"
+
+    fun: string-downcase
+
+templates:
+- test.scm: |
+
+    (display ({{ fun }} "Hello!")

--- a/test/string-eq.yaml
+++ b/test/string-eq.yaml
@@ -1,0 +1,30 @@
+cases:
+  - name: basic true
+    status: 0
+    stdout: "#t"
+
+    t: "\"Hello world!\""
+
+  - name: basic false
+    status: 0
+    stdout: "#f"
+
+    t: "\"Not\""
+
+  - name: basic multiple args true
+    status: 0
+    stdout: "#t"
+
+    t: "s \"Hello world!\""
+
+  - name: basic multiple args false
+    status: 0
+    stdout: "#f"
+
+    t: "s \"Nope\""
+
+templates:
+- test.scm: |
+
+    (define s "Hello world!")
+    (display (string=? s {{ t }})

--- a/test/string-fill.yaml
+++ b/test/string-fill.yaml
@@ -1,0 +1,25 @@
+cases:
+  - name: basic
+    status: 0
+    stdout: "TTTTT"
+
+    args: ""
+
+  - name: with start
+    status: 0
+    stdout: "HeTTT"
+
+    args: 2
+
+  - name: with start and end
+    status: 0
+    stdout: "HeTTo"
+
+    args: 2 4
+
+templates:
+- test.scm: |
+
+    (define s "Hello")
+    (string-fill! s {{ args }})
+    (display s)

--- a/test/string-fill.yaml
+++ b/test/string-fill.yaml
@@ -3,23 +3,23 @@ cases:
     status: 0
     stdout: "TTTTT"
 
-    args: ""
+    argv: ""
 
   - name: with start
     status: 0
     stdout: "HeTTT"
 
-    args: 2
+    argv: 2
 
   - name: with start and end
     status: 0
     stdout: "HeTTo"
 
-    args: 2 4
+    argv: 2 4
 
 templates:
 - test.scm: |
 
     (define s "Hello")
-    (string-fill! s {{ args }})
+    (string-fill! s \#T {{ argv }})
     (display s)

--- a/test/string-length.yaml
+++ b/test/string-length.yaml
@@ -1,0 +1,9 @@
+cases:
+  - name: basic
+    status: 0
+    stdout: 12
+
+templates:
+- test.scm: |
+
+    (display (string-length "Hello world!")

--- a/test/string-ref.yaml
+++ b/test/string-ref.yaml
@@ -1,0 +1,9 @@
+cases:
+  - name: basic
+    status: 0
+    stdout: "#\e"
+
+templates:
+- test.scm: |
+
+    (display (string-ref "Hello world!" 1)

--- a/test/string-ref.yaml
+++ b/test/string-ref.yaml
@@ -1,7 +1,7 @@
 cases:
   - name: basic
     status: 0
-    stdout: "#\e"
+    stdout: "#\\e"
 
 templates:
 - test.scm: |

--- a/test/string-set.yaml
+++ b/test/string-set.yaml
@@ -7,5 +7,5 @@ templates:
 - test.scm: |
 
     (define s "Hello world!")
-    (string-set s 0 #\C)
+    (string-set! s 0 #\C)
     (display s)

--- a/test/string-set.yaml
+++ b/test/string-set.yaml
@@ -1,0 +1,11 @@
+cases:
+  - name: basic
+    status: 0
+    stdout: "Cello world!"
+
+templates:
+- test.scm: |
+
+    (define s "Hello world!")
+    (string-set s 0 #\C)
+    (display s)

--- a/test/string-to-list.yaml
+++ b/test/string-to-list.yaml
@@ -1,0 +1,9 @@
+cases:
+  - name: basic
+    status: 0
+    stdout: "(#\\H #\\e #\\l #\\l #\\o)"
+
+templates:
+- test.scm: |
+
+    (display (string->list "Hello"))

--- a/test/stringp.yaml
+++ b/test/stringp.yaml
@@ -1,0 +1,17 @@
+cases:
+  - name: basic true
+    status: 0
+    stdout: "#t"
+
+    v: "\"Hello world!\""
+
+  - name: basic false
+    status: 0
+    stdout: "#f"
+
+    v: 1
+
+templates:
+- test.scm: |
+
+    (display (string? {{ v }})

--- a/test/substring.yaml
+++ b/test/substring.yaml
@@ -1,0 +1,9 @@
+cases:
+  - name: basic
+    status: 0
+    stdout: "Hello"
+
+templates:
+- test.scm: |
+
+    (display (substring "Hello world!" 0 5))


### PR DESCRIPTION
This PR adds character literal support (e.g. `#\c`) and many string methods:

* string?
* make-string
* string
* string-length
* string-ref
* string=?
* string-append
* list->string
* string-set!
* string-fill!
* string-upcase
* string-downcase
* substring
* string->list

This is a little more than half of the string methods needed to meet R7RS.

This PR also adds begin statements implicitly to function bodies.