### PR TITLE
Add stacktrace to interpreter and implement simple TCO

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,9 @@ $ ./a
   * Read / eval / include
   * Comments
   * Command-line REPL
+  * `if`, `let`, `define`, `begin` tail calls optimized
 * Missing (but planned, R7RS is the obvious goal):
-  * Tail-call optimization
   * Macros
-  * Dotted pair syntax
   * Labelled let
   * Modules
   * D FFI

--- a/examples/letstar.scm
+++ b/examples/letstar.scm
@@ -1,0 +1,5 @@
+(define (main)
+  (let* ((a 1)
+         (b (+ 1 a)))
+    (display (+ a b))
+    (newline)))

--- a/examples/recursion-tco-begin.scm
+++ b/examples/recursion-tco-begin.scm
@@ -1,0 +1,8 @@
+(define (exp base pow accum)
+  (if (= pow 0)
+      accum
+      (begin (stacktrace) (exp base (- pow 1) (* accum base)))))
+
+(define (main)
+  (display (exp 2 100 1))
+  (newline))

--- a/examples/recursion-tco.scm
+++ b/examples/recursion-tco.scm
@@ -1,0 +1,8 @@
+(define (exp base pow accum)
+  (if (= pow 0)
+      accum
+      (exp base (- pow 1) (* accum base))))
+
+(define (main)
+  (display (exp 2 100 1))
+  (newline))

--- a/examples/recursion.scm
+++ b/examples/recursion.scm
@@ -1,8 +1,8 @@
-(define (exp base pow)
+(define (exp base pow accum)
   (if (= pow 0)
-      1
-      (* base (exp base (- pow 1)))))
+      accum
+      (exp base (- pow 1) (* accum base))))
 
 (define (main)
-  (display (exp 2 62))
+  (display (exp 2 100 1))
   (newline))

--- a/examples/recursion.scm
+++ b/examples/recursion.scm
@@ -1,8 +1,8 @@
-(define (exp base pow accum)
+(define (exp base pow)
   (if (= pow 0)
-      accum
-      (exp base (- pow 1) (* accum base))))
+      1
+      (* base (exp base (- pow 1)))))
 
 (define (main)
-  (display (exp 2 100 1))
+  (display (exp 2 16))
   (newline))

--- a/examples/stacktrace.scm
+++ b/examples/stacktrace.scm
@@ -1,0 +1,11 @@
+(define (b arg)
+  (stacktrace)
+  (display arg)
+  (newline))
+
+(define (a arg)
+  (b (+ arg 1)))
+
+(define (main)
+  (a 1)
+  (a (a 2)))

--- a/src/backends/d/bsdc.d
+++ b/src/backends/d/bsdc.d
@@ -235,7 +235,7 @@ int main(string[] args) {
   compile(withBegin(value), &ctx, &pgm);
 
   string[] dImports = ["std.stdio"];
-  string[] localDImports = ["lex", "common", "parse", "utility", "value"];
+  string[] localDImports = ["lex", "common", "parse", "utility", "value", "buffer"];
 
   foreach (imp; dImports ~ localDImports) {
     pgm.external ~= format("import %s;", imp);

--- a/src/backends/interpreter/bsdi.d
+++ b/src/backends/interpreter/bsdi.d
@@ -36,9 +36,9 @@ int main(string[] args) {
     auto topLevelItem = makeListValue(include, includeArgs);
     eval(topLevelItem, cast(void**)[ctx]);
 
-    if (!valueIsNil(ctx.get("main"))) {
+    if (!valueIsNil(ctx.get("main", false))) {
       auto fn = valueToFunction(ctx.get("main"));
-      fn[1](nilValue, cast(void**)0);
+      fn[1](nilValue, cast(void**)[ctx]);
     }
   } else {
     info();

--- a/src/backends/interpreter/runtime.d
+++ b/src/backends/interpreter/runtime.d
@@ -25,7 +25,7 @@ Value mapValues(Value delegate(Value, void**, bool) f, Value arguments, void** r
 
   auto iterator = arguments;
   while (valueIsList(iterator)) {
-    Value mappedElement = f(car(iterator), rest, valueIsNil(cdr(iterator)));
+    Value mappedElement = f(car(iterator), rest, false);
     mapped = appendList(mapped, makeListValue(mappedElement, nilValue));
     iterator = cdr(iterator);
   }

--- a/src/backends/interpreter/runtime.d
+++ b/src/backends/interpreter/runtime.d
@@ -373,6 +373,20 @@ Value stacktrace(Value arguments, void** rest) {
   return nilValue;
 }
 
+Value begin(Value arguments, void** rest) {
+  Value result = arguments;
+
+  auto iterator = arguments;
+  while (!valueIsNil(iterator)) {
+    auto exp = car(iterator);
+    bool tcoPosition = valueIsNil(cdr(iterator));
+    result = eval(exp, rest, tcoPosition);
+    iterator = cdr(iterator);
+  }
+
+  return result;
+}
+
 class Context {
   Buffer!(Tuple!(string, Delegate)) callingContext;
   Delegate doTailCall;
@@ -389,7 +403,6 @@ class Context {
       "cons": &cons,
       "car": &_car,
       "cdr": &_cdr,
-      "begin": &begin,
       "display": &display,
       "newline": &newline,
       "read": &_read,
@@ -419,6 +432,7 @@ class Context {
     ];
 
     this.builtinSpecials = [
+      "begin": &begin,
       "if": &ifFun,
       "let": &let,
       "let*": &letStar,

--- a/src/buffer.d
+++ b/src/buffer.d
@@ -1,0 +1,59 @@
+class Buffer(T) {
+  int index;
+  T[] buffer;
+
+  this(T[] buffer) {
+    this.buffer = buffer;
+    this.index = 0;
+  }
+
+  this() {
+    this.buffer = [];
+    this.buffer.length = 16;
+  }
+
+  T current() {
+    return this.buffer[this.index];
+  }
+
+  bool next() {
+    if (this.index + 1 >= this.buffer.length) {
+      return false;
+    }
+
+    this.index++;
+    return true;
+  }
+
+  void increase(int size) {
+    this.buffer.length += size;
+  }
+
+  bool previous() {
+    if (this.index == 0) {
+      return false;
+    }
+
+    this.index--;
+    return true;
+  }
+
+  void push(T item) {
+    if (this.index / this.buffer.length > .75) {
+      this.buffer.length *= 2;
+    }
+
+    this.buffer[this.index++] = item;
+  }
+
+  T pop() {
+    return this.buffer[this.index--];
+  }
+
+  Buffer!T dup() {
+    auto dup = new Buffer!T();
+    dup.buffer = buffer.dup;
+    dup.index = index;
+    return dup;
+  }
+}

--- a/src/common.d
+++ b/src/common.d
@@ -299,7 +299,7 @@ Value stringAppend(Value arguments, void** rest) {
 }
 
 Value listToString(Value arguments, void** rest) {
-  return stringFun(car(arguments), cast(void**)0);
+  return stringFun(car(arguments), null);
 }
 
 Value stringUpcase(Value arguments, void** rest) {
@@ -437,5 +437,5 @@ Value _read(Value arguments, void** rest) {
   Value arg1 = car(arguments);
   string s = valueToString(arg1);
   string sWithBegin = format("(begin %s)", s);
-  return quote(parse.read(sWithBegin.dup), cast(void**)0);
+  return quote(parse.read(sWithBegin.dup), null);
 }

--- a/src/lex.d
+++ b/src/lex.d
@@ -2,6 +2,8 @@ import std.conv;
 import std.string;
 import std.stdio;
 
+import buffer;
+
 enum TokenType {
   LeftParen,
   RightParen,
@@ -25,59 +27,6 @@ struct Token {
   string value;
   TokenType type;
   SchemeType schemeType;
-}
-
-class Buffer(T) {
-  int index;
-  T[] buffer;
-
-  this(T[] buffer) {
-    this.buffer = buffer;
-    this.index = 0;
-  }
-
-  this() {
-    this.buffer = [];
-    this.buffer.length = 16;
-  }
-
-  T current() {
-    return this.buffer[this.index];
-  }
-
-  bool next() {
-    if (this.index + 1 >= this.buffer.length) {
-      return false;
-    }
-
-    this.index++;
-    return true;
-  }
-
-  void increase(int size) {
-    this.buffer.length += size;
-  }
-
-  bool previous() {
-    if (this.index == 0) {
-      return false;
-    }
-
-    this.index--;
-    return true;
-  }
-
-  void push(T item) {
-    if (this.index / this.buffer.length > .75) {
-      this.buffer.length *= 2;
-    }
-
-    this.buffer[this.index++] = item;
-  }
-
-  T pop() {
-    return this.buffer[this.index--];
-  }
 }
 
 alias Buffer!(char) StringBuffer;

--- a/tests/recursion.yaml
+++ b/tests/recursion.yaml
@@ -24,10 +24,10 @@ cases:
 templates:
 - test.scm: |
 
-    (define (exp base pow)
+    (define (exp base pow accum)
       (if (= pow 0)
-          1
-          (* base (exp base (- pow 1)))))
+          accum
+          (exp base (- pow 1) (* accum base))))
 
     (define (main)
-      (display (exp {{ b }} {{ p }})))
+      (display (exp {{ b }} {{ p }} 1)))


### PR DESCRIPTION
Adds a `stacktrace` form for printing out the callstack.

Implements TCO for `if` and `begin` forms which should also cover `define` and `let` because they wrap their body in `begin`.

Also fixes let scoping and adds let* support.