### PR TITLE
Add basic unimplemented forms to compiler

### DIFF
--- a/examples/lambda.scm
+++ b/examples/lambda.scm
@@ -1,0 +1,3 @@
+(define (main)
+  (define a 1)
+  (display ((lambda (b) (+ a b)) 12)))

--- a/examples/map.scm
+++ b/examples/map.scm
@@ -2,5 +2,5 @@
   (+ a 1))
 
 (define (main)
-  (display (for-each pp (list 1 2 3)))
+  (display (map pp (list 1 2 3)))
   (newline))

--- a/examples/map.scm
+++ b/examples/map.scm
@@ -2,4 +2,5 @@
   (+ a 1))
 
 (define (main)
-  (map pp (list 1 2 3)))
+  (display (for-each pp (list 1 2 3)))
+  (newline))

--- a/examples/map.scm
+++ b/examples/map.scm
@@ -2,5 +2,5 @@
   (+ a 1))
 
 (define (main)
-  (display (map pp (list 1 2 3)))
+  (display (map pp '(1 2 3)))
   (newline))

--- a/examples/map.scm
+++ b/examples/map.scm
@@ -1,0 +1,5 @@
+(define (pp a)
+  (+ a 1))
+
+(define (main)
+  (map pp (list 1 2 3)))

--- a/examples/quote.scm
+++ b/examples/quote.scm
@@ -1,3 +1,3 @@
-(display (quote (1 2)))
-
-(newline)
+(define (main)
+  (display (quote ((+ 1 2) "foo" (- "foo" "bar"))))
+  (newline))

--- a/src/backends/d/cg.d
+++ b/src/backends/d/cg.d
@@ -1,6 +1,7 @@
 import std.array;
 import std.format;
 import std.stdio;
+import std.string;
 
 import ir;
 
@@ -52,6 +53,8 @@ class CG {
       return MapCG.fromIR(mir);
     } else if (auto lir = cast(ListIR)ir) {
       return ListCG.fromIR(lir);
+    } else if (auto qir = cast(QuoteIR)ir) {
+      return QuoteCG.fromIR(qir);
     } else {
       cgError(format("Invalid IR."));
       assert(0);
@@ -214,5 +217,12 @@ class ListCG : CG {
                   init,
                   lir.returnVariable,
                   returns.join(", "));
+  }
+}
+
+class QuoteCG : CG {
+  static string fromIR(QuoteIR qir) {
+    auto safeSerialized = qir.serialized.translate(['"': "\\\""]);
+    return format("Value %s = car(read(\"%s\".dup))", qir.tmp, safeSerialized);
   }
 }

--- a/src/backends/d/cg.d
+++ b/src/backends/d/cg.d
@@ -63,6 +63,8 @@ class FuncallCG : CG {
   static string fromIR(FuncallIR fir) {
     string[] argInitializers;
     string[] args;
+
+    string fnInit = fir.init is null ? "" : format("%s;\n\t", CG.fromIR(fir.init, false));
     
     foreach (arg; fir.arguments) {
       if (nonLiteral(arg)) {
@@ -76,7 +78,8 @@ class FuncallCG : CG {
       initializers ~= ";\n\t";
     }
 
-    return format("%s\n\tValue %s = %s(vectorToList([%s]), null)",
+    return format("%s%s\n\tValue %s = %s(vectorToList([%s]), null)",
+                  fnInit,
                   initializers,
                   fir.returnVariable,
                   fir.name,
@@ -86,11 +89,8 @@ class FuncallCG : CG {
 
 class DefineFunctionCG : CG {
   static string fromIR(DefineFunctionIR fir) {
-    
-
     string functionHeader = format("Value %s(Value %s, void** ctx) {\n\t", fir.name, ARGUMENTS);
     string functionFooter = format("}\n");
-
 
     string block = fir.parameters.length ?
       format("Value[] %s = listToVector(%s);\n\t", fir.tmp, ARGUMENTS) :
@@ -100,8 +100,7 @@ class DefineFunctionCG : CG {
     }
 
     block ~= BeginCG.fromIR(fir.block, false);
-
-    block ~= format(";\n\treturn %s;\n", CG.fromIR(fir.getReturnIR(), false));
+    block ~= format(";\n\treturn %s;\n", CG.fromIR(fir.block.getReturnIR(), false));
 
     return format("%s%s%s", functionHeader, block, functionFooter);
   }

--- a/src/backends/d/ir.d
+++ b/src/backends/d/ir.d
@@ -133,6 +133,8 @@ class FuncallIR : IR {
         return ListIR.fromAST(v[1], ctx);
       case "lambda":
         return LambdaIR.fromAST(v[1], ctx);
+      case "quote":
+        return QuoteIR.fromAST(v[1], ctx);
       default:
         break;
       }
@@ -455,5 +457,21 @@ class LambdaIR : IR {
                                              car(value)),
                                              cdr(value));
     return DefineIR.fromAST(defineArgsTransform, ctx);
+  }
+}
+
+class QuoteIR : IR {
+  string tmp;
+  string serialized;
+
+  static IR fromAST(Value value, Context ctx) {
+    auto qir = new QuoteIR;
+    qir.tmp = ctx.setTmp("quoted");
+    qir.serialized = formatValue(car(value));
+    return qir;
+  }
+
+  override IR getReturnIR() {
+    return new VariableIR(tmp);
   }
 }


### PR DESCRIPTION
Adds support for:
* map
* for-each
* list
* quote
* lambda

Quote is stupidly implemented but is actually pretty similar from what I can tell to how Chicken Scheme works. It serializes the quoted content to a string and then the resulting program `read`s the string during execution.